### PR TITLE
[Bug Fix] Fix spelling error in DSC

### DIFF
--- a/OemPkg/OemPkg.dsc
+++ b/OemPkg/OemPkg.dsc
@@ -77,7 +77,7 @@
 
   GraphicsConsoleHelperLib|PcBdsPkg/Library/GraphicsConsoleHelperLib/GraphicsConsoleHelper.inf
   MsBootOptionsLib|PcBdsPkg/Library/MsBootOptionsLib/MsBootOptionsLib.inf
-  MsPlatformDevicesLib|PcBdsPkg/Library/MsPlatformDevicesNullLib/MsPlatformDevicesNullLib.inf
+  MsPlatformDevicesLib|PcBdsPkg/Library/MsPlatformDevicesLibNull/MsPlatformDevicesLibNull.inf
 
   MsAltBootLib|OemPkg/Library/MsAltBootLib/MsAltBootLib.inf
   MsBootPolicyLib|OemPkg/Library/MsBootPolicyLib/MsBootPolicyLib.inf


### PR DESCRIPTION
As part of commit 2729e97c in Mu Plus, the MsPlatformDeviceLibNull was renamed to MsPlatformDevicesNullLib to be more consistent. This is just an update to follow that update.