### PR TITLE
Add missing required libraries to MsSecureBootLib

### DIFF
--- a/OemPkg/Library/MsSecureBootLib/MsSecureBootLib.inf
+++ b/OemPkg/Library/MsSecureBootLib/MsSecureBootLib.inf
@@ -34,6 +34,8 @@
   DebugLib
   PlatformKeyLib
   UefiBootServicesTableLib
+  UefiRuntimeServicesTableLib
+  MemoryAllocationLib
 
 
 [Protocols]


### PR DESCRIPTION
These have previously been aliased from drivers that include the lib, but should
be in the lib itself.