### PR TITLE
 Replace obsolete modules with new.

### DIFF
--- a/FrontpageDsc.inc
+++ b/FrontpageDsc.inc
@@ -8,7 +8,7 @@
   ShellCEntryLib|ShellPkg/Library/UefiShellCEntryLib/UefiShellCEntryLib.inf
   HandleParsingLib|ShellPkg/Library/UefiHandleParsingLib/UefiHandleParsingLib.inf
   BcfgCommandLib|ShellPkg/Library/UefiShellBcfgCommandLib/UefiShellBcfgCommandLib.inf
-  NetLib|MdeModulePkg/Library/DxeNetLib/DxeNetLib.inf
+  NetLib|NetworkPkg/Library/DxeNetLib/DxeNetLib.inf
   #
   # Contains intrinsics for crypto operations
   #
@@ -28,7 +28,7 @@
   #
   # Stubs functions that should contain base logic for querying, setting, and verifying user passwords.
   #
-  DfciPasswordLib|DfciPkg/Library/DfciPasswordLibNull/DfciPasswordLibNull.inf
+  DfciPasswordLib|DfciPkg/Library/DfciPasswordProvider/DfciPasswordProvider.inf
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
   #
   # Supports DFCI Groups.
@@ -107,7 +107,7 @@
   # Library to help set the console to known points (low res, native res)
   #
   GraphicsConsoleHelperLib|PcBdsPkg/Library/GraphicsConsoleHelperLib/GraphicsConsoleHelper.inf
-  DeviceStateLib|MsCorePkg/Library/DeviceStateLib/DeviceStateLib.inf
+  MdeModulePkg|MsCorePkg/Library/DeviceStateLib/DeviceStateLib.inf
   #
   # Device specific actions in support of PlatformBootManagerLib.
   # Sort of a wrapper for MsPlatformDevicesLib, which needs to be written for each platform.

--- a/FrontpageDsc.inc
+++ b/FrontpageDsc.inc
@@ -107,7 +107,7 @@
   # Library to help set the console to known points (low res, native res)
   #
   GraphicsConsoleHelperLib|PcBdsPkg/Library/GraphicsConsoleHelperLib/GraphicsConsoleHelper.inf
-  MdeModulePkg|MsCorePkg/Library/DeviceStateLib/DeviceStateLib.inf
+  DeviceStateLib|MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.inf
   #
   # Device specific actions in support of PlatformBootManagerLib.
   # Sort of a wrapper for MsPlatformDevicesLib, which needs to be written for each platform.


### PR DESCRIPTION
Hello,
I found several obsolete module references in ```FrontpageDsc. inc``` . So I spent some time looking at the change history of these modules and replacing them with new ones.
Here is the basis for the changes:

1. change ```NetLib|MdeModulePkg/Library/DxeNetLib/DxeNetLib.inf``` to ```NetLib|NetworkPkg/Library/DxeNetLib/DxeNetLib.inf```.
  https://github.com/microsoft/mu_basecore/commit/4542f8b8135f1f1ee5654e25139be9769e139ddd

2. change ```DfciPasswordLib|DfciPkg/Library/DfciPasswordLibNull/DfciPasswordLibNull.inf``` to ```DfciPasswordLib|DfciPkg/Library/DfciPasswordProvider/DfciPasswordProvider.inf```
  https://github.com/microsoft/mu_plus/commit/547721ef04d0c708396696b66f77ec06ab1598eb

3. change ```DeviceStateLib|MsCorePkg/Library/DeviceStateLib/DeviceStateLib.inf``` to ```DeviceStateLib|MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.inf```
  https://github.com/microsoft/mu_plus/commit/65be2fa186be26e110eec238f6135c43f460246d

If there are any mistakes, feel free to correct them.
