### PR TITLE
Update ci dependencies

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -190,6 +190,11 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
                 "Path": "Common/MU_TIANO",
                 "Url": "https://github.com/Microsoft/mu_tiano_plus.git",
                 "Branch": "release/202208"
+            },
+            {
+                "Path": "MU_FEATURE_DFCI",
+                "Url": "https://github.com/microsoft/mu_feature_dfci.git",
+                "Branch": "main"
             }
         ]
 

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.12.1
+edk2-pytool-library~=0.13.0
 edk2-pytool-extensions~=0.21.1
 edk2-basetools==0.1.29
 antlr4-python3-runtime==4.11.1


### PR DESCRIPTION
## Description

Updates CI dependencies to download the new feature repo for DFCI and also upgrades edk2-pytool-library to v0.13.0 to support changes made in MU_BASECORE.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Passes CI

## Integration Instructions

N/A
