### PR TITLE
Add CodeQL Stuart parameter to this repo

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -5,8 +5,10 @@
 # Copyright (c) 2020 - 2021, ARM Limited. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
+import glob
 import os
 import logging
+import sys
 from edk2toolext.environment import shell_environment
 from edk2toolext.invocables.edk2_ci_build import CiBuildSettingsManager
 from edk2toolext.invocables.edk2_ci_setup import CiSetupSettingsManager
@@ -14,6 +16,15 @@ from edk2toolext.invocables.edk2_setup import SetupSettingsManager, RequiredSubm
 from edk2toolext.invocables.edk2_update import UpdateSettingsManager
 from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
 from edk2toollib.utility_functions import GetHostInfo
+from pathlib import Path
+
+try:
+    # May not be present until submodules are populated
+    root = Path(__file__).parent.parent.resolve()
+    sys.path.append(str(root/'MU_BASECORE'/'.pytool'/'Plugin'/'CodeQL'/'integration'))
+    import stuart_codeql as codeql_helpers
+except ImportError:
+    pass
 
 
 class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsManager, SetupSettingsManager, PrEvalSettingsManager):
@@ -35,12 +46,22 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
         group.add_argument("-force_piptools", "--fpt", dest="force_piptools", action="store_true", default=False, help="Force the system to use pip tools")
         group.add_argument("-no_piptools", "--npt", dest="no_piptools", action="store_true", default=False, help="Force the system to not use pip tools")
 
+        try:
+            codeql_helpers.add_command_line_option(parserObj)
+        except NameError:
+            pass
+
     def RetrieveCommandLineOptions(self, args):
 		# MU_CHANGE - Don't call super....lots of issues...see pytools docs...super().RetrieveCommandLineOptions(args)
         if args.force_piptools:
             self.UseBuiltInBaseTools = True
         if args.no_piptools:
             self.UseBuiltInBaseTools = False
+
+        try:
+            self.codeql = codeql_helpers.is_codeql_enabled_on_command_line(args)
+        except NameError:
+            pass
 
     # ####################################################################################### #
     #                        Default Support for this Ci Build                                #
@@ -149,7 +170,28 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
                     scopes += ("gcc_arm_linux",)
                 if "RISCV64" in self.ActualArchitectures:
                     scopes += ("gcc_riscv64_unknown",)
+
+            try:
+                scopes += codeql_helpers.get_scopes(self.codeql)
+
+                if self.codeql:
+                    shell_environment.GetBuildVars().SetValue(
+                        "STUART_CODEQL_AUDIT_ONLY",
+                        "TRUE",
+                        "Set in CISettings.py")
+                    codeql_filter_files = [str(n) for n in glob.glob(
+                        os.path.join(self.GetWorkspaceRoot(),
+                            '**/CodeQlFilters.yml'),
+                        recursive=True)]
+                    shell_environment.GetBuildVars().SetValue(
+                        "STUART_CODEQL_FILTER_FILES",
+                        ','.join(codeql_filter_files),
+                        "Set in CISettings.py")
+            except NameError:
+                pass
+
             self.ActualScopes = scopes
+
         return self.ActualScopes
 
     def GetRequiredSubmodules(self):


### PR DESCRIPTION
## Description

Allows CodeQL to be run locally by specifying `--codeql` when
providing `stuart_update` and `stuart_ci_build` commands in this
repo.

- `stuart_update` - Automatically downloads the CodeQL CLI application
  appropriate for your host operating system
  - Note: This may take several minutes depending on your Internet
    connection speed
- `stuart_ci_build` - Automatically runs CodeQL against the packages
  built after they are built.

NOTE: Running with CodeQL will increase your overall build time for a
couple of reasons:

1. Every package must be clean built to get proper results
2. The CodeQL analysis phase takes a while to run

  (1) happens automatically, you do not need to specify a clean build
  manually

For more information, such as:

1. How to view results
2. How to modify the CodeQL rules run
3. How to include/exclude files/rules at various levels of granularity

And more...

Go to the CodeQL plugin readme:

https://github.com/microsoft/mu_basecore/blob/HEAD/.pytool/Plugin/CodeQL/Readme.md

---

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified `--codeql` usage with `stuart_update` and `stuart_ci_build` locally.

## Integration Instructions

See earlier PR description and CodeQL plugin readme:

https://github.com/microsoft/mu_basecore/blob/HEAD/.pytool/Plugin/CodeQL/Readme.md

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>