### PR TITLE
Add Configuration Profile Support

### DIFF
--- a/OemPkg/Library/ActiveProfileIndexSelectorPcdLib/ActiveProfileIndexSelectorPcdLib.c
+++ b/OemPkg/Library/ActiveProfileIndexSelectorPcdLib/ActiveProfileIndexSelectorPcdLib.c
@@ -1,0 +1,45 @@
+/** @file ActiveProfileIndexSelectorPcdLib.c
+  PCD instance of ActiveProfileIndexSelectorLib. It is expected that the OEM/Platform
+  will override this library to query the current boot active profile index from the
+  proper source of truth.
+
+  This library reads gOemPkgTokenSpaceGuid.PcdActiveProfileIndex and returns the active
+  profile index.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/PcdLib.h>
+#include <Library/ActiveProfileIndexSelectorLib.h>
+
+/**
+  Return which profile is the active profile for this boot.
+  This function validates the profile GUID is valid.
+
+  @param[out] ActiveProfileIndex  The index for the active profile. A value of MAX_UINT32, when combined with a return
+                                  value of EFI_SUCCESS, indicates that the default profile has been chosen. If the
+                                  return value is not EFI_SUCCESS, the value of ActiveProfileIndex shall not be updated.
+
+  @retval EFI_INVALID_PARAMETER   Input argument is null.
+  @retval EFI_NO_RESPONSE         The source of truth for profile selection has returned a garbage value or not replied.
+  @retval EFI_SUCCESS             The operation succeeds and ActiveProfileIndex contains the valid active profile
+                                  index for this boot.
+**/
+EFI_STATUS
+EFIAPI
+GetActiveProfileIndex (
+  OUT UINT32  *ActiveProfileIndex
+  )
+{
+  if (ActiveProfileIndex == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Just return what the PCD has, the caller should valid it
+  *ActiveProfileIndex = FixedPcdGet32 (PcdActiveProfileIndex);
+
+  return EFI_SUCCESS;
+}

--- a/OemPkg/Library/ActiveProfileIndexSelectorPcdLib/ActiveProfileIndexSelectorPcdLib.c
+++ b/OemPkg/Library/ActiveProfileIndexSelectorPcdLib/ActiveProfileIndexSelectorPcdLib.c
@@ -38,7 +38,7 @@ GetActiveProfileIndex (
     return EFI_INVALID_PARAMETER;
   }
 
-  // Just return what the PCD has, the caller should valid it
+  // Just return what the PCD has, the caller should validate it
   *ActiveProfileIndex = FixedPcdGet32 (PcdActiveProfileIndex);
 
   return EFI_SUCCESS;

--- a/OemPkg/Library/ActiveProfileIndexSelectorPcdLib/ActiveProfileIndexSelectorPcdLib.inf
+++ b/OemPkg/Library/ActiveProfileIndexSelectorPcdLib/ActiveProfileIndexSelectorPcdLib.inf
@@ -1,0 +1,30 @@
+## @file ActiveProfileIndexSelectorPcdLib.inf
+# PCD instance of ActiveProfileIndexSelectorLib to pick a profile based on
+# value of PcdActiveProfileIndex
+#
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION         = 0x00010017
+  BASE_NAME           = ActiveProfileIndexSelectorPcdLib
+  FILE_GUID           = 4F334BDD-9C31-4244-8E27-153E450C8B58
+  VERSION_STRING      = 1.0
+  MODULE_TYPE         = BASE
+  LIBRARY_CLASS       = ActiveProfileIndexSelectorLib
+
+[Sources]
+  ActiveProfileIndexSelectorPcdLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  SetupDataPkg/SetupDataPkg.dec
+  OemPkg/OemPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  PcdLib
+
+[Pcd]
+  gOemPkgTokenSpaceGuid.PcdActiveProfileIndex ## CONSUMES

--- a/OemPkg/Library/PlatformConfigDataNullLib/PlatformConfigDataNullLib.c
+++ b/OemPkg/Library/PlatformConfigDataNullLib/PlatformConfigDataNullLib.c
@@ -11,6 +11,7 @@
 #include <Uefi.h>
 #include <ConfigStdStructDefs.h>
 
-KNOB_DATA  gKnobData = { 0 };
-
-UINTN  gNumKnobs = 0;
+KNOB_DATA  gKnobData    = { 0 };
+UINTN      gNumKnobs    = 0;
+PROFILE    gProfileData = { 0 };
+UINTN      gNumProfiles = 0;

--- a/OemPkg/OemConfigPolicyCreatorPei/OemConfigPolicyCreatorPei.c
+++ b/OemPkg/OemConfigPolicyCreatorPei/OemConfigPolicyCreatorPei.c
@@ -59,7 +59,7 @@ ApplyProfileOverrides (
         ));
 
       // we may have failed in the middle of applying the profile, so we need to
-      // write the default value for each knob we may have passed to it's cache address so we can
+      // write the default value for each knob we may have passed to its cache address so we can
       // have a clean generic profile. We didn't apply the knob for this value of i, so decrement
       // before we start
       i--;

--- a/OemPkg/OemConfigPolicyCreatorPei/OemConfigPolicyCreatorPei.inf
+++ b/OemPkg/OemConfigPolicyCreatorPei/OemConfigPolicyCreatorPei.inf
@@ -32,6 +32,7 @@
   ConfigVariableListLib
   ConfigKnobShimLib
   SafeIntLib
+  ActiveProfileIndexSelectorLib
 
 [Ppis]
   gPeiPolicyPpiGuid                   ## CONSUMES

--- a/OemPkg/OemPkg.dec
+++ b/OemPkg/OemPkg.dec
@@ -97,3 +97,7 @@
   # then user can access the front page as a limited user.
   # If set to 0 gives an unlimited number of attempts.
   gOemPkgTokenSpaceGuid.PcdMaxPasswordAttempts|0x3|UINT8|0x0000000B
+
+  ## Pcd for ActiveProfileIndexSelectorPcdLib to query ActiveProfileIndex from
+  # MAX_UINT32 indicates the default profile
+  gOemPkgTokenSpaceGuid.PcdActiveProfileIndex|0xffffffff|UINT32|0x0000000C

--- a/OemPkg/OemPkg.dsc
+++ b/OemPkg/OemPkg.dsc
@@ -83,6 +83,7 @@
   PlatformPKProtectionLib|SecurityPkg/Library/PlatformPKProtectionLibVarPolicy/PlatformPKProtectionLibVarPolicy.inf
 
   ConfigVariableListLib|SetupDataPkg/Library/ConfigVariableListLib/ConfigVariableListLib.inf
+  ActiveProfileIndexSelectorLib|OemPkg/Library/ActiveProfileIndexSelectorPcdLib/ActiveProfileIndexSelectorPcdLib.inf
 
 [LibraryClasses.IA32]
   MsUiThemeLib|MsGraphicsPkg/Library/MsUiThemeLib/Pei/MsUiThemeLib.inf
@@ -149,6 +150,7 @@
       # platform data lib
       NULL|OemPkg/Library/PlatformConfigDataNullLib/PlatformConfigDataNullLib.inf
   }
+  OemPkg/Library/ActiveProfileIndexSelectorPcdLib/ActiveProfileIndexSelectorPcdLib.inf
 
 [Components.IA32]
   OemPkg/DeviceStatePei/DeviceStatePei.inf


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This adds XML Configuration Profile support to mu_oem_sample's OemConfigPolicyCreatorPei. This uses the new functionality in mu_feature_config to support profiles and is intended to be consumed in mu_tiano_platforms.

OemConfigPolicyCreatorPei now receives profile data, queries the active profile index from a library, and applies the profile to the config policy, if it is applicable. Then, UEFI variables are read to determine if there are any overrides to the profile values.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by integrating to mu_tiano_platforms and booting into different profiles.

## Integration Instructions

Add an ActiveProfileIndexSelectorLib library class to your DSC.