### PR TITLE
Clears the DebugDirectory of the Debug information for Release builds of HelloUefi

### DIFF
--- a/OemPkg/HelloUefi/HelloUefi.inf
+++ b/OemPkg/HelloUefi/HelloUefi.inf
@@ -33,3 +33,6 @@
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
+
+[BuildOptions]
+  RELEASE_GCC5_*_GENFW_FLAGS = -z


### PR DESCRIPTION

# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This is a workaround for an issue in GenFw

On linux when building using GCC5 in RELEASE the PE DebugDirectory includes the full path to the intermittent DLL.

See:

00000330: 3403 0000 4e42 3130 0000 0000 0000 0000  4...NB10........
00000340: 0000 0000 2f68 6f6d 652f 7573 6572 2d78  ..../home/user-x
00000350: 782f 6d75 5f6f 656d 5f73 616d 706c 652f  x/mu_oem_sample/
00000360: 4275 696c 642f 4f65 6d50 6b67 2f52 454c  Build/OemPkg/REL
00000370: 4541 5345 5f47 4343 352f 5836 342f 4f65  EASE_GCC5/X64/Oe
00000380: 6d50 6b67 2f48 656c 6c6f 5565 6669 2f48  mPkg/HelloUefi/H
00000390: 656c 6c6f 5565 6669 2f44 4542 5547 2f48  elloUefi/DEBUG/H
000003a0: 656c 6c6f 5565 6669 2e64 6c6c 0000 0000  elloUefi.dll....
000003b0: 0000 0000 0000 0000 0000 0000 0000 0000  ................

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [X] Impacts functionality?
- Simply zeros out the timestamps and debug directory using GenFW
- [ ] Impacts security?
- [ ] Breaking change?
  - If anyone is actually consuming the DebugDirectory, this would be a breaking change. This is mitigated by only removing it in this application on RELEASE builds.
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built on WSL2 Ubuntu with GCC5 tool chain

## Integration Instructions

N/A