### PR TITLE
Fix Possible BootMenu Failure

### DIFF
--- a/OemPkg/BootMenu/BootMenu.c
+++ b/OemPkg/BootMenu/BootMenu.c
@@ -552,6 +552,7 @@ BootMenuEntry (
     DEBUG ((DEBUG_ERROR, "%a: Error on HiiAddPackages. Code=%r\n", __FUNCTION__, Status));
   } else {
     Status = gBS->LocateProtocol (&gEdkiiFormBrowserEx2ProtocolGuid, NULL, (VOID **)&mBrowserEx2);
+    ASSERT_EFI_ERROR (Status);
   }
 
   return EFI_SUCCESS;

--- a/OemPkg/BootMenu/BootMenu.c
+++ b/OemPkg/BootMenu/BootMenu.c
@@ -550,13 +550,11 @@ BootMenuEntry (
                                  );
   if (mBootMenuPrivate.HiiHandle == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Error on HiiAddPackages. Code=%r\n", __FUNCTION__, Status));
-
-    return EFI_OUT_OF_RESOURCES;
+  } else {
+    Status = gBS->LocateProtocol (&gEdkiiFormBrowserEx2ProtocolGuid, NULL, (VOID **)&mBrowserEx2);
   }
 
-  Status = gBS->LocateProtocol (&gEdkiiFormBrowserEx2ProtocolGuid, NULL, (VOID **)&mBrowserEx2);
-
-  return Status;
+  return EFI_SUCCESS;
 }
 
 /**

--- a/OemPkg/BootMenu/BootMenu.inf
+++ b/OemPkg/BootMenu/BootMenu.inf
@@ -68,4 +68,4 @@
 [Pcd]
 
 [Depex]
-  TRUE
+  gEdkiiFormBrowserEx2ProtocolGuid


### PR DESCRIPTION
## Description
BootMenu should have a DEPEX on gEdkiiFormBrowserEx2ProtocolGuid and should not return failure (to avoid unloading the driver after creating events and installing protocol interfaces).

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35

## Integration Instructions

N/A