### PR TITLE
.git-blame-ignore-revs: Ignore Line Ending and Uncrustify only commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,13 @@
+###################################################
+# Line Ending Only Changes                        #
+###################################################
+# Fix line endings (LF to CRLF)
+66656ef038ac9a34ce3d10f4ef3d19d3cc5b7c06
+
+###################################################
+# Code Formatting (Uncrustify) Only Changes       #
+###################################################
+# Fixing Uncrustify break
+2ca270b989185eba7782a24bd19c1fcb9a7b5cd2
+# Uncrustify: Fix up all source files to match coding policy
+a0db1b30cff65401ed68ef510ddeb725c3c4c868


### PR DESCRIPTION
## Description

Adds commits that only applied Uncrustify formatting or converted
line endings to a .git-blame-ignore-revs file so they are ignored
by git blame. This is supported by GitHub:
https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/

This helps clean up git blame by filtering out these changes.

Note: This file needs to be updated on rebase branches. Processes
      like filter-branch can automatically update relevant SHAs.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- `git blame`

## Integration Instructions

N/A