### PR TITLE
OemPkg: DfciDeviceIdSupportLib: Fixing uninitialized variable being used

### DIFF
--- a/OemPkg/Library/DfciDeviceIdSupportLib/DfciDeviceIdSupportLib.c
+++ b/OemPkg/Library/DfciDeviceIdSupportLib/DfciDeviceIdSupportLib.c
@@ -100,13 +100,15 @@ DfciIdSupportV1GetSerialNumber (
   EFI_SMBIOS_HANDLE        SmbiosHandle;
   EFI_SMBIOS_TABLE_HEADER  *Record;
   SMBIOS_TYPE              Type;
-  SMBIOS_TABLE_TYPE1       *Type1Record;
+  SMBIOS_TABLE_TYPE1       *Type1Record = NULL;
 
   SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;      // Reset handle
   Type         = SMBIOS_TYPE_SYSTEM_INFORMATION; // Smbios type1
   Status       = mSmbiosProtocol->GetNext (mSmbiosProtocol, &SmbiosHandle, &Type, &Record, NULL);
   if (!EFI_ERROR (Status)) {
     Type1Record = (SMBIOS_TABLE_TYPE1 *)Record;
+  } else {
+    goto Exit;
   }
 
   Status = GetOptionalStringByIndex ((CHAR8 *)((UINT8 *)Type1Record + Type1Record->Hdr.Length), Type1Record->SerialNumber, &NewString, NULL);
@@ -115,6 +117,7 @@ DfciIdSupportV1GetSerialNumber (
     FreePool (NewString);
   }
 
+Exit:
   return Status;
 }
 
@@ -139,7 +142,7 @@ DfciIdSupportGetManufacturer (
   EFI_SMBIOS_HANDLE        SmbiosHandle;
   EFI_SMBIOS_TABLE_HEADER  *Record;
   SMBIOS_TYPE              Type;
-  SMBIOS_TABLE_TYPE1       *Type1Record;
+  SMBIOS_TABLE_TYPE1       *Type1Record = NULL;
 
   if (Manufacturer == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -150,9 +153,13 @@ DfciIdSupportGetManufacturer (
   Status       = mSmbiosProtocol->GetNext (mSmbiosProtocol, &SmbiosHandle, &Type, &Record, NULL);
   if (!EFI_ERROR (Status)) {
     Type1Record = (SMBIOS_TABLE_TYPE1 *)Record;
+  } else {
+    goto Exit;
   }
 
   Status = GetOptionalStringByIndex ((CHAR8 *)((UINT8 *)Type1Record + Type1Record->Hdr.Length), Type1Record->Manufacturer, Manufacturer, ManufacturerSize);
+
+Exit:
   return Status;
 }
 
@@ -177,7 +184,7 @@ DfciIdSupportGetProductName (
   EFI_SMBIOS_HANDLE        SmbiosHandle;
   EFI_SMBIOS_TABLE_HEADER  *Record;
   SMBIOS_TYPE              Type;
-  SMBIOS_TABLE_TYPE1       *Type1Record;
+  SMBIOS_TABLE_TYPE1       *Type1Record = NULL;
 
   if (ProductName == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -188,9 +195,13 @@ DfciIdSupportGetProductName (
   Status       = mSmbiosProtocol->GetNext (mSmbiosProtocol, &SmbiosHandle, &Type, &Record, NULL);
   if (!EFI_ERROR (Status)) {
     Type1Record = (SMBIOS_TABLE_TYPE1 *)Record;
+  } else {
+    goto Exit;
   }
 
   Status = GetOptionalStringByIndex ((CHAR8 *)((UINT8 *)Type1Record + Type1Record->Hdr.Length), Type1Record->ProductName, ProductName, ProductNameSize);
+
+Exit:
   return Status;
 }
 
@@ -215,7 +226,7 @@ DfciIdSupportGetSerialNumber (
   EFI_SMBIOS_HANDLE        SmbiosHandle;
   EFI_SMBIOS_TABLE_HEADER  *Record;
   SMBIOS_TYPE              Type;
-  SMBIOS_TABLE_TYPE3       *Type3Record;
+  SMBIOS_TABLE_TYPE3       *Type3Record = NULL;
 
   if (SerialNumber == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -226,9 +237,13 @@ DfciIdSupportGetSerialNumber (
   Status       = mSmbiosProtocol->GetNext (mSmbiosProtocol, &SmbiosHandle, &Type, &Record, NULL);
   if (!EFI_ERROR (Status)) {
     Type3Record = (SMBIOS_TABLE_TYPE3 *)Record;
+  } else {
+    goto Exit;
   }
 
   Status = GetOptionalStringByIndex ((CHAR8 *)((UINT8 *)Type3Record + Type3Record->Hdr.Length), Type3Record->SerialNumber, SerialNumber, SerialNumberSize);
+
+Exit:
   return Status;
 }
 


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

There are a few instances where the variables could be used without being initialized in DfciDeviceIdSupportLib. This change is made to fix such cases.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on QEMU Q35 and booted to UEFI shell.

## Integration Instructions

N/A
