### PR TITLE
OemPkg: MuUefiVersionLib Fix ClangDwarf compile.

### DIFF
--- a/OemPkg/Library/MuUefiVersionLib/MuUefiVersionLib.c
+++ b/OemPkg/Library/MuUefiVersionLib/MuUefiVersionLib.c
@@ -59,6 +59,7 @@ typedef union {
 **/
 STATIC
 UINTN
+EFIAPI
 VerifyStringLength (
   IN  UINTN         TargetLength,
   IN  CONST CHAR16  *Template,


### PR DESCRIPTION
## Description

When comping with clangdwarf, the abi defaults to system v abi. The use of VA_ARG with clang, defaults to the msabi version.

Functions that use VA_ARG should be declared as EFIAPI. In this particular case, the function is internal, and was not declared with EFIAPI. Adding the missing declaration resolves the build error.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [X] Backport to release branch?

## How This Was Tested
Testing while building a platform using TOOL_CHAIN_TAG=CLANGDWARF

## Integration Instructions
No integration necessary