### PR TITLE
Adding DXE counterparts of some drivers

### DIFF
--- a/OemPkg/DeviceStateDxe/DeviceStateDxe.c
+++ b/OemPkg/DeviceStateDxe/DeviceStateDxe.c
@@ -30,8 +30,8 @@ BOOLEAN
 IsSecureBootOn (
   )
 {
-  EFI_STATUS                       Status;
-  UINTN                            PkSize  = 0;
+  EFI_STATUS  Status;
+  UINTN       PkSize = 0;
 
   Status = gRT->GetVariable (EFI_PLATFORM_KEY_NAME, &gEfiGlobalVariableGuid, NULL, &PkSize, NULL);
   if ((Status == EFI_BUFFER_TOO_SMALL) && (PkSize > 0)) {

--- a/OemPkg/DeviceStateDxe/DeviceStateDxe.c
+++ b/OemPkg/DeviceStateDxe/DeviceStateDxe.c
@@ -1,0 +1,73 @@
+/** @file DeviceStateDxe.c
+
+  This platform module sets the DEVICE_STATE bits prior to display.
+
+  This driver currently implements the following bits in a standard method:
+    DEVICE_STATE_SECUREBOOT_OFF
+
+  This library can either mask those bits (force low) or add other bits.  See the
+  MdeModulePkg/Include/Library/DeviceStateLib.h file for bit definitions.
+
+  Copyright (C) Microsoft Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <PiDxe.h>
+#include <Library/DebugLib.h>
+#include <Library/DeviceStateLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+
+#include <Guid/GlobalVariable.h>
+
+/**
+  Helper function to query whether the secure boot variable is in place.
+  For Project Mu Code if the PK is set then Secure Boot is enforced (there is no
+  SetupMode)
+
+  @retval     TRUE if secure boot is enabled, FALSE otherwise.
+**/
+BOOLEAN
+IsSecureBootOn (
+  )
+{
+  EFI_STATUS                       Status;
+  UINTN                            PkSize  = 0;
+
+  Status = gRT->GetVariable (EFI_PLATFORM_KEY_NAME, &gEfiGlobalVariableGuid, NULL, &PkSize, NULL);
+  if ((Status == EFI_BUFFER_TOO_SMALL) && (PkSize > 0)) {
+    DEBUG ((DEBUG_INFO, "%a - PK exists.  Secure boot on.  Pk Size is 0x%X\n", __FUNCTION__, PkSize));
+    return TRUE;
+  }
+
+  DEBUG ((DEBUG_INFO, "%a - PK doesn't exist.  Secure boot off\n", __FUNCTION__));
+  return FALSE;
+}
+
+/**
+  Module Entrypoint.
+  Check States and Set State
+
+  @param[in]  FileHandle    Handle of the file being invoked.
+  @param[in]  SystemTable   Pointer to the system table.
+
+  @retval     EFI_SUCCESS  Always returns success.
+**/
+EFI_STATUS
+EFIAPI
+DeviceStateDxeEntry (
+  IN EFI_HANDLE        FileHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  DEVICE_STATE  State;
+
+  State = 0;
+
+  if (!IsSecureBootOn ()) {
+    State |= DEVICE_STATE_SECUREBOOT_OFF;
+  }
+
+  AddDeviceState (State);
+
+  return EFI_SUCCESS;
+}

--- a/OemPkg/DeviceStateDxe/DeviceStateDxe.inf
+++ b/OemPkg/DeviceStateDxe/DeviceStateDxe.inf
@@ -31,6 +31,7 @@
   UefiDriverEntryPoint
   DebugLib
   DeviceStateLib
+  UefiRuntimeServicesTableLib
 
 [Guids]
   gEfiGlobalVariableGuid

--- a/OemPkg/DeviceStateDxe/DeviceStateDxe.inf
+++ b/OemPkg/DeviceStateDxe/DeviceStateDxe.inf
@@ -1,0 +1,39 @@
+## @file DeviceStateDxe.inf
+#
+#  This module checks a device state platform conditions and sets the state
+#  accordingly.
+#
+#  This driver currently implements the following bits in a standard method:
+#    DEVICE_STATE_SECUREBOOT_OFF
+#
+#  Copyright (C) Microsoft Corporation.
+#
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010017
+  BASE_NAME                      = DeviceStateDxe
+  FILE_GUID                      = E3CCCDB0-145F-46DC-9CA9-CC83A84DB3A3
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = DeviceStateDxeEntry
+
+[Sources]
+  DeviceStateDxe.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  UefiDriverEntryPoint
+  DebugLib
+  DeviceStateLib
+
+[Guids]
+  gEfiGlobalVariableGuid
+
+[Depex]
+  gEfiVariableWriteArchProtocolGuid     # Needed to query variable storage

--- a/OemPkg/OemConfigPolicyCreatorDxe/OemConfigPolicyCreatorDxe.c
+++ b/OemPkg/OemConfigPolicyCreatorDxe/OemConfigPolicyCreatorDxe.c
@@ -1,0 +1,358 @@
+/** @file
+  This module receives the static platform data for a platform and creates a config policy. It is intended to run
+  before a platform level Silicon Policy Creator that maps this config policy to silicon policy.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+#include <ConfigStdStructDefs.h>
+
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Guid/VariableFormat.h>
+#include <Guid/OemConfigMetadataPolicy.h>
+#include <Library/ConfigVariableListLib.h>
+#include <Library/ConfigKnobShimLib.h>
+#include <Library/SafeIntLib.h>
+#include <Library/PolicyLib.h>
+#include <Library/ActiveProfileIndexSelectorLib.h>
+#include <Library/PlatformConfigDataLib.h>
+
+/**
+  Helper function to apply profile overrides. This function is only
+  called if the active profile index has been validated to be within
+  the acceptable range.
+
+  @param[in]  ActiveProfileIndex The validated index into gProfileData
+
+  @retval     EFI_SUCCESS        Successfully applied the input profile index
+  @retval     !EFI_SUCCESS       Failed to apply the input profile index, applied generic profile instead
+**/
+STATIC
+EFI_STATUS
+ApplyProfileOverrides (
+  UINT32  ActiveProfileIndex
+  )
+{
+  PROFILE  *ActiveProfile = &gProfileData[ActiveProfileIndex];
+  UINTN    i;
+  UINTN    Knob;
+
+  for (i = 0; i < ActiveProfile->OverrideCount; i++) {
+    Knob = ActiveProfile->Overrides[i].Knob;
+    if ((Knob >= gNumKnobs) || (Knob != gKnobData[Knob].Knob)) {
+      // something bad happened in the autogeneration, knobs are
+      // not ordered. Don't muck about finding the misordered knobs
+      // fail
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a knob autogeneration out of order, can't finish applying profile, defaulting to generic profile\n",
+        __FUNCTION__
+        ));
+
+      // we may have failed in the middle of applying the profile, so we need to
+      // write the default value for each knob we may have passed to its cache address so we can
+      // have a clean generic profile. We didn't apply the knob for this value of i, so decrement
+      // before we start
+      if (i == 0) {
+        return EFI_INVALID_PARAMETER;
+      }
+
+      i--;
+      for ( ; i > 0; i--) {
+        Knob = ActiveProfile->Overrides[i].Knob;
+        CopyMem (gKnobData[Knob].CacheValueAddress, gKnobData[Knob].DefaultValueAddress, gKnobData[Knob].ValueSize);
+      }
+
+      // do this once more when i == 0. To keep signed/unsigned comparisons issues in check, i is not signed
+      // otherwise we'd do >= 0 in the loop
+      Knob = ActiveProfile->Overrides[i].Knob;
+      CopyMem (gKnobData[Knob].CacheValueAddress, gKnobData[Knob].DefaultValueAddress, gKnobData[Knob].ValueSize);
+
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    CopyMem (gKnobData[Knob].CacheValueAddress, ActiveProfile->Overrides[i].Value, gKnobData[Knob].ValueSize);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Helper function to create config policy.
+
+  @param[out]      ConfPolicy     Pointer to uninitialized config policy
+  @param[out]      ConfPolicySize Pointer to size of created ConfPolicy
+
+  @retval EFI_SUCCESS           The configuration is translated to policy successfully.
+  @retval EFI_OUT_OF_RESOURCES  Memory allocation failed.
+  @retval EFI_NOT_READY         Variable Services were not found.
+  @retval EFI_ABORTED           Creating variable list failed.
+  @retval Others                Other errors occurred when getting GFX policy.
+**/
+STATIC
+EFI_STATUS
+CreateConfPolicy (
+  OUT  VOID     **ConfPolicy,
+  OUT   UINT16  *ConfPolicySize
+  )
+{
+  EFI_STATUS                  Status;
+  UINT32                      i;
+  UINT32                      NeededSize = 0;
+  UINT32                      Offset     = 0;
+  CHAR16                      UnicodeName[CONF_VAR_NAME_LEN];           // get a buffer of the max name size
+  CONFIG_VAR_LIST_ENTRY       VarListEntry;
+  UINTN                       VarListSize;
+  VOID                        *ConfListPtr;
+  UINT32                      UnicodeNameSize;
+  UINT32                      TmpNeededSize;
+  UINT32                      ActiveProfileIndex;
+  OEM_CONFIG_METADATA_POLICY  ConfigMetadata;
+  CHAR8                       *ProfileName;
+
+  // first figure out how much space we need to allocate for the ConfPolicy
+  for (i = 0; i < gNumKnobs; i++) {
+    Status = (EFI_STATUS)SafeUint32Mult (gKnobData[i].NameSize, 2, &UnicodeNameSize);
+    if (EFI_ERROR (Status)) {
+      // we overflowed
+      DEBUG ((DEBUG_ERROR, "%a config knob has too long a name! Size: 0x%x\n", __FUNCTION__, gKnobData[i].NameSize * 2));
+      ASSERT (FALSE);
+      Status = EFI_UNSUPPORTED;
+      goto CreatePolicyExit;
+    }
+
+    // the var list will use the Unicode version of the name, gKnobData has the ASCII version
+    Status = GetVarListSize (UnicodeNameSize, gKnobData[i].ValueSize, &TmpNeededSize);
+    if (EFI_ERROR (Status)) {
+      // we overflowed
+      DEBUG ((DEBUG_ERROR, "%a Config var list is too large!\n", __FUNCTION__));
+      ASSERT (FALSE);
+      Status = EFI_UNSUPPORTED;
+      goto CreatePolicyExit;
+    }
+
+    Status = (EFI_STATUS)SafeUint32Add (NeededSize, TmpNeededSize, &NeededSize);
+    if (EFI_ERROR (Status)) {
+      // we overflowed
+      DEBUG ((DEBUG_ERROR, "%a config exceeds max size!\n", __FUNCTION__));
+      ASSERT (FALSE);
+      Status = EFI_UNSUPPORTED;
+      goto CreatePolicyExit;
+    }
+  }
+
+  Status = (EFI_STATUS)SafeUint32ToUint16 (NeededSize, ConfPolicySize);
+  // validate we won't overflow the maximum size allowed for policy service. In addition, don't
+  // overflow the DataSize (UINT32) of VarListEntry
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a config is greater than 64k! Too large for what policy service supports\n", __FUNCTION__));
+    ASSERT (FALSE);
+    Status = EFI_UNSUPPORTED;
+    goto CreatePolicyExit;
+  }
+
+  *ConfPolicy = AllocatePool (NeededSize);
+
+  if (*ConfPolicy == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a failed to allocate Conf Policy memory!\n", __FUNCTION__));
+    ASSERT (FALSE);
+    Status = EFI_OUT_OF_RESOURCES;
+    goto CreatePolicyExit;
+  }
+
+  // before we get potential overrides for the policy, we need to figure out which
+  // profile will be our active one for this boot and apply any overrides from it
+  // to the cache
+  Status = GetActiveProfileIndex (&ActiveProfileIndex);
+  if (EFI_ERROR (Status)) {
+    // if we fail to get the active profile index, default to the generic profile
+    DEBUG ((DEBUG_ERROR, "%a failed to get active profile index! Defaulting to generic profile\n", __FUNCTION__));
+    ActiveProfileIndex = GENERIC_PROFILE_INDEX;
+  }
+
+  if (ActiveProfileIndex < gNumProfiles) {
+    // if ActiveProfileIndex == GENERIC_PROFILE_INDEX, we are using the generic profile and don't
+    // look for any profile overrides. Otherwise, ensure that the active profile index
+    // is valid, otherwise use the generic profile. If it is valid, apply those overrides.
+    Status = ApplyProfileOverrides (ActiveProfileIndex);
+    if (EFI_ERROR (Status)) {
+      // if we failed to apply the profile, we defaulted to the generic profile
+      // mark that here so we report it in the config metadata policy
+      ActiveProfileIndex = GENERIC_PROFILE_INDEX;
+    }
+  } else if (ActiveProfileIndex != GENERIC_PROFILE_INDEX) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a bad value of ActiveProfileIndex returned: %d, defaulting to generic profile\n",
+      __FUNCTION__,
+      ActiveProfileIndex
+      ));
+    ActiveProfileIndex = GENERIC_PROFILE_INDEX;
+  }
+
+  // now go through and populate the Conf Policy
+  for (i = 0; i < gNumKnobs; i++) {
+    AsciiStrToUnicodeStrS (gKnobData[i].Name, UnicodeName, gKnobData[i].NameSize);
+
+    VarListEntry.Name = UnicodeName;
+    VarListEntry.Guid = gKnobData[i].VendorNamespace;
+    // hardcoded for now
+    VarListEntry.Attributes = VARIABLE_ATTRIBUTE_NV_BS_RT;
+    VarListEntry.Data       = gKnobData[i].CacheValueAddress;
+    // this is validated not to overflow above where we ensure the entire config
+    // NeededSize is not greater than MAX_UINT16 and NeededSize is takes each knob's
+    // ValueSize into consideration
+    VarListEntry.DataSize = (UINT32)gKnobData[i].ValueSize;
+
+    // check if value has been overridden in variable storage
+    Status = GetConfigKnobOverride (
+               &gKnobData[i].VendorNamespace,
+               UnicodeName,
+               gKnobData[i].CacheValueAddress,
+               gKnobData[i].ValueSize
+               );
+
+    // if variable services fails other than failing to find the variable (it was not overridden)
+    // or a size mismatch (stale data from a previous definition of the knob), we should fail
+    // as we may be missing overridden knobs
+    if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND) && (Status != EFI_BAD_BUFFER_SIZE)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a variable services failed to find %a with status (%r)\n",
+        __FUNCTION__,
+        gKnobData[i].Name,
+        Status
+        ));
+      ASSERT (FALSE);
+      goto CreatePolicyExit;
+    }
+
+    // Validate the value from flash meets the constraints of the knob
+    if ((Status == EFI_SUCCESS) && (gKnobData[i].Validator != NULL)) {
+      if (!gKnobData[i].Validator (gKnobData[i].CacheValueAddress)) {
+        // If it doesn't, we will set the value to the default value
+        DEBUG ((DEBUG_ERROR, "Config knob %a failed validation!\n", gKnobData[i].Name));
+        CopyMem (gKnobData[i].CacheValueAddress, gKnobData[i].DefaultValueAddress, gKnobData[i].ValueSize);
+      }
+    }
+
+    ConfListPtr = ((UINT8 *)*ConfPolicy) + Offset;
+
+    VarListSize = (UINTN)NeededSize - (UINTN)Offset;
+    Status      = ConvertVariableEntryToVariableList (&VarListEntry, ConfListPtr, &VarListSize);
+
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a failed to convert variable entry to var list! - %r\n", __FUNCTION__, Status));
+      ASSERT (FALSE);
+      goto CreatePolicyExit;
+    }
+
+    Offset += (UINT32)VarListSize;
+  }
+
+  if (Offset != NeededSize) {
+    // oops we messed up the math, may have corrupted memory...
+    DEBUG ((DEBUG_ERROR, "%a expected ConfPolicy size %x does not match actual size %x!\n", __FUNCTION__, NeededSize, Offset));
+    ASSERT (Offset == NeededSize);
+    Status = EFI_ABORTED;
+    goto CreatePolicyExit;
+  }
+
+  // Publish the config metadata policy
+  ConfigMetadata.ActiveProfileIndex = ActiveProfileIndex;
+  if (ConfigMetadata.ActiveProfileIndex == GENERIC_PROFILE_INDEX) {
+    ProfileName = (CHAR8 *)GENERIC_PROFILE_FLAVOR_NAME;
+  } else {
+    ProfileName = gProfileFlavorNames[ActiveProfileIndex];
+  }
+
+  Status = AsciiStrCpyS (&ConfigMetadata.ActiveProfileFlavorName[0], PROFILE_FLAVOR_NAME_LENGTH, ProfileName);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a Failed to copy flavor name! Status (%r)\n", __FUNCTION__, Status));
+    goto CreatePolicyExit;
+  }
+
+  Status = SetPolicy (
+             &gOemConfigMetadataPolicyGuid,
+             POLICY_ATTRIBUTE_FINALIZED,
+             &ConfigMetadata,
+             OEM_CONFIG_METADATA_POLICY_SIZE
+             );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a Failed to set config metadata policy! Status (%r)\n", __func__, Status));
+    goto CreatePolicyExit;
+  }
+
+CreatePolicyExit:
+  if (EFI_ERROR (Status)) {
+    *ConfPolicySize = 0;
+
+    if (*ConfPolicy != NULL) {
+      FreePool (*ConfPolicy);
+    }
+  }
+
+  return Status;
+}
+
+/**
+  Module entry point that will check configuration data and publish them to policy database.
+
+  @param ImageHandle                    The image handle.
+  @param SystemTable                    The system table.
+
+  @retval Status                        From internal routine or boot object, should not fail
+**/
+EFI_STATUS
+EFIAPI
+OemConfigPolicyCreatorDxeEntry (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *ConfPolicy    = NULL;
+  UINT16      ConfPolicySize = 0;
+
+  DEBUG ((DEBUG_INFO, "%a - Entry.\n", __FUNCTION__));
+
+  // Oem can choose to do any Oem specific things to config here such as enforcing static only config or
+  // selecting a configuration profile based on some criteria
+  Status = CreateConfPolicy (&ConfPolicy, &ConfPolicySize);
+
+  if (EFI_ERROR (Status) || (ConfPolicy == NULL) || (ConfPolicySize == 0)) {
+    DEBUG ((DEBUG_ERROR, "%a CreateConfPolicy failed! Status (%r)\n", __FUNCTION__, Status));
+    ASSERT (FALSE);
+    goto Exit;
+  }
+
+  // Publish immutable config policy
+  // Policy Service will receive gOemConfigPolicyGuid and publish it as a PPI so that the Silicon Policy Creator can
+  // have a depex on it and map it to Silicon Policies
+  Status = SetPolicy (&gOemConfigPolicyGuid, POLICY_ATTRIBUTE_FINALIZED, ConfPolicy, ConfPolicySize);
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a Failed to set config policy! Status (%r)\n", __FUNCTION__, Status));
+    ASSERT (FALSE);
+    goto Exit;
+  }
+
+Exit:
+  // Policy Service copies the policy, so we can free this memory
+  if (ConfPolicy != NULL) {
+    FreePool (ConfPolicy);
+  }
+
+  // return success even in failure scenarios as returning a failure from an entry point can cause the image to be
+  // unloaded. In this way depend modules can come up and run their own failure scenarios for not finding the config
+  // policy
+  return EFI_SUCCESS;
+}

--- a/OemPkg/OemConfigPolicyCreatorDxe/OemConfigPolicyCreatorDxe.inf
+++ b/OemPkg/OemConfigPolicyCreatorDxe/OemConfigPolicyCreatorDxe.inf
@@ -1,0 +1,46 @@
+## @file OemConfigPolicyCreatorDxe.inf
+#
+#  This module receives the static platform data for a platform and creates a config policy. It is intended to run
+#  before a platform level Silicon Policy Creator that maps this config policy to silicon policy.
+#
+#  Copyright (C) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010017
+  BASE_NAME                      = OemConfigPolicyCreatorDxe
+  FILE_GUID                      = 8C809563-A6CD-4E1C-B02D-E0F92EFA70F0
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = OemConfigPolicyCreatorDxeEntry
+
+[Sources]
+  OemConfigPolicyCreatorDxe.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  PolicyServicePkg/PolicyServicePkg.dec
+  SetupDataPkg/SetupDataPkg.dec
+  OemPkg/OemPkg.dec
+
+[LibraryClasses]
+  UefiDriverEntryPoint
+  DebugLib
+  ConfigVariableListLib
+  ConfigKnobShimLib
+  SafeIntLib
+  ActiveProfileIndexSelectorLib
+  PolicyLib
+
+[Protocols]
+  gPolicyProtocolGuid                 ## CONSUMES
+
+[Guids]
+  gOemConfigPolicyGuid                # Guid that config policy is filed under
+  gOemConfigMetadataPolicyGuid        # Guid that config metadata policy is filed under
+
+[Depex]
+  gPolicyProtocolGuid AND             # Needed to file config policy
+  gEfiVariableWriteArchProtocolGuid   # Needed to query variable storage

--- a/OemPkg/OemPkg.dsc
+++ b/OemPkg/OemPkg.dsc
@@ -139,8 +139,14 @@
       # platform data lib
       NULL|SetupDataPkg/Library/PlatformConfigDataLibNull/PlatformConfigDataLibNull.inf
   }
+  OemPkg/OemConfigPolicyCreatorDxe/OemConfigPolicyCreatorDxe.inf {
+    <LibraryClasses>
+      # platform data lib
+      NULL|SetupDataPkg/Library/PlatformConfigDataLibNull/PlatformConfigDataLibNull.inf
+  }
   OemPkg/Library/ActiveProfileIndexSelectorPcdLib/ActiveProfileIndexSelectorPcdLib.inf
   OemPkg/HelloUefi/HelloUefi.inf
+  OemPkg/DeviceStateDxe/DeviceStateDxe.inf
 
 [Components.IA32]
   OemPkg/DeviceStatePei/DeviceStatePei.inf

--- a/OemPkg/OemPkg.dsc
+++ b/OemPkg/OemPkg.dsc
@@ -91,6 +91,7 @@
 [LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
   PolicyLib|PolicyServicePkg/Library/DxePolicyLib/DxePolicyLib.inf
+  ConfigKnobShimLib|SetupDataPkg/Library/ConfigKnobShimLib/ConfigKnobShimDxeLib/ConfigKnobShimDxeLib.inf
 
 [LibraryClasses.common.PEIM]
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf


### PR DESCRIPTION
## Description

This change adds the drivers to cover the corresponding usage if there is no PEI phase in the platform.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU SBSA platform after switching it to PEIless SEC.

## Integration Instructions

N/A
