### PR TITLE
OemPkg: Physical Presence Variable Update

### DIFF
--- a/OemPkg/Library/DeviceBootManagerLib/DeviceBootManagerLib.c
+++ b/OemPkg/Library/DeviceBootManagerLib/DeviceBootManagerLib.c
@@ -36,6 +36,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PcdLib.h>
 #include <Library/PrintLib.h>
 #include <Library/PowerServicesLib.h>
+#include <Library/Tcg2PhysicalPresenceLib.h>
 #include <Library/ThermalServicesLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
@@ -808,6 +809,8 @@ DeviceBootManagerAfterConsole (
       Status = TpmPp->PromptForConfirmation (TpmPp);
       DEBUG ((DEBUG_ERROR, "%a: Unexpected return from Tpm Physical Presence. Code=%r\n", __FUNCTION__, Status));
     }
+
+    Tcg2PhysicalPresenceLibProcessRequest (NULL);
   }
 
   return GetPlatformConnectList ();

--- a/OemPkg/Library/DeviceBootManagerLib/DeviceBootManagerLib.inf
+++ b/OemPkg/Library/DeviceBootManagerLib/DeviceBootManagerLib.inf
@@ -26,6 +26,7 @@
   MsGraphicsPkg/MsGraphicsPkg.dec
   PcBdsPkg/PcBdsPkg.dec
   DfciPkg/DfciPkg.dec
+  SecurityPkg/SecurityPkg.dec
   ShellPkg/ShellPkg.dec
   MsWheaPkg/MsWheaPkg.dec
 
@@ -44,6 +45,7 @@
   MsBootPolicyLib
   MsBootManagerSettingsLib
   MsPlatformPowerCheckLib
+  Tcg2PhysicalPresenceLib
   ThermalServicesLib
   PowerServicesLib
   MsNVBootReasonLib


### PR DESCRIPTION
## Description

Added call to Tcg2PhysicalPresenceLibProcessRequest which will create the physical presence NV variable if it doesn't exist. This makes it so that calls in the TpmShellApp to the physical presence interface won't fail due to not finding the physical presence variable.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built Qemu Q35 with TPM enabled, verified functionality via the TpmShellApp.

## Integration Instructions

N/A
