### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -29,5 +29,5 @@ jobs:
 
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot'
-    uses: microsoft/mu_devops/.github/workflows/AutoApprover.yml@v10.0.0
+    uses: microsoft/mu_devops/.github/workflows/AutoApprover.yml@467a1ca439187c1c4a8d43c65a84a6a1cd5a294d # v10.0.0
     secrets: inherit

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -32,5 +32,5 @@ jobs:
 
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot'
-    uses: microsoft/mu_devops/.github/workflows/AutoMerger.yml@v10.0.0
+    uses: microsoft/mu_devops/.github/workflows/AutoMerger.yml@467a1ca439187c1c4a8d43c65a84a6a1cd5a294d # v10.0.0
     secrets: inherit

--- a/.github/workflows/clangpdb-ci.yml
+++ b/.github/workflows/clangpdb-ci.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   package-matrix:
     name: Gather Repository Packages
-    uses: microsoft/mu_devops/.github/workflows/PackageMatrix.yml@v18.0.7
+    uses: microsoft/mu_devops/.github/workflows/PackageMatrix.yml@131433bb4f29d68250154cc66096f04c19fe3ee9 # v18.0.7
     with:
       ci-config: '.pytool/CISettings.py'
       python-version: "3.12"
@@ -49,7 +49,7 @@ jobs:
 
     needs: package-matrix
 
-    uses: microsoft/mu_devops/.github/workflows/PackageCi.yml@v18.0.7
+    uses: microsoft/mu_devops/.github/workflows/PackageCi.yml@131433bb4f29d68250154cc66096f04c19fe3ee9 # v18.0.7
 
     with:
       runner: windows-latest
@@ -65,7 +65,7 @@ jobs:
 
     needs: package-matrix
 
-    uses: microsoft/mu_devops/.github/workflows/PackageCi.yml@v18.0.7
+    uses: microsoft/mu_devops/.github/workflows/PackageCi.yml@131433bb4f29d68250154cc66096f04c19fe3ee9 # v18.0.7
 
     with:
       runner: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,12 +49,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
 
 
     - name: Install Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.12'
 
@@ -102,12 +102,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
 
 
     - name: Install Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.12'
         cache: 'pip'
@@ -233,7 +233,7 @@ jobs:
 
     - name: Download cargo-make
       if: steps.cargo_make_cache.outputs.cache-hit != 'true'
-      uses: robinraju/release-downloader@v1.13
+      uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1
       with:
         repository: 'sagiegurari/cargo-make'
         tag: '${{ steps.get_cargo_tool_details.outputs.cargo_make_version }}'
@@ -274,7 +274,7 @@ jobs:
       run: stuart_setup -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload Setup Log As An Artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: (success() || failure()) && steps.get_ci_file_operations.outputs.setup_supported == 'true'
       with:
         name: ${{ matrix.package }}-Setup-Log
@@ -288,7 +288,7 @@ jobs:
       run: stuart_ci_setup -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload CI Setup Log As An Artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: (success() || failure()) && steps.get_ci_file_operations.outputs.ci_setup_supported == 'true'
       with:
         name: ${{ matrix.package }}-CI-Setup-Log
@@ -301,7 +301,7 @@ jobs:
       run: stuart_update -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload Update Log As An Artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: success() || failure()
       with:
         name: ${{ matrix.package }}-Update-Log
@@ -367,7 +367,7 @@ jobs:
 
     - name: Attempt to Load CodeQL CLI From Cache
       id: codeqlcli_cache
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ steps.cache_key_gen.outputs.codeql_cli_ext_dep_dir }}
         key: ${{ steps.cache_key_gen.outputs.codeql_cli_cache_key }}
@@ -453,7 +453,7 @@ jobs:
         delete_dirs(build_path)
 
     - name: Upload Build Logs As An Artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: success() || failure()
       with:
         name: ${{ matrix.package }}-Build-Logs
@@ -484,7 +484,7 @@ jobs:
             print(f'sarif_file_path={sarif_path}', file=fh)
 
     - name: Upload CodeQL Results (SARIF) As An Artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ matrix.package }}-CodeQL-SARIF
         path: ${{ steps.env_data.outputs.sarif_file_path }}
@@ -492,7 +492,7 @@ jobs:
         if-no-files-found: warn
 
     - name: Upload CodeQL Results (SARIF) To GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         # Path to SARIF file relative to the root of the repository.
         sarif_file: ${{ steps.env_data.outputs.sarif_file_path }}
@@ -513,7 +513,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Create Empty SARIF
       shell: python
@@ -540,7 +540,7 @@ jobs:
             json.dump(sarif, f)
 
     - name: Upload Empty SARIF To GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         sarif_file: empty.sarif
         category: no-packages

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -19,5 +19,5 @@ on:
 jobs:
   apply:
 
-    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v18.0.7
+    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@131433bb4f29d68250154cc66096f04c19fe3ee9 # v18.0.7
     secrets: inherit

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -31,5 +31,5 @@ on:
 
 jobs:
   apply:
-    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v18.0.7
+    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@131433bb4f29d68250154cc66096f04c19fe3ee9 # v18.0.7
     secrets: inherit

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -25,5 +25,5 @@ on:
 jobs:
   sync:
 
-    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v18.0.7
+    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@131433bb4f29d68250154cc66096f04c19fe3ee9 # v18.0.7
     secrets: inherit

--- a/.github/workflows/pull-request-formatting-validator.yml
+++ b/.github/workflows/pull-request-formatting-validator.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Generate Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.MU_ACCESS_APP_ID }}
           private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
@@ -68,7 +68,7 @@ jobs:
 
       - name: Check for Validation Errors
         if: env.VALIDATION_ERROR
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             core.setFailed('PR Formatting Validation Check Failed!')

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -29,5 +29,5 @@ jobs:
   draft:
     name: Draft Releases
 
-    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v18.0.7
+    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@131433bb4f29d68250154cc66096f04c19fe3ee9 # v18.0.7
     secrets: inherit

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Generate Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.MU_ACCESS_APP_ID }}
           private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,5 +25,5 @@ on:
 jobs:
   check:
 
-    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v18.0.7
+    uses: microsoft/mu_devops/.github/workflows/Stale.yml@131433bb4f29d68250154cc66096f04c19fe3ee9 # v18.0.7
     secrets: inherit

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -20,5 +20,5 @@ on:
 jobs:
   triage:
 
-    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v18.0.7
+    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@131433bb4f29d68250154cc66096f04c19fe3ee9 # v18.0.7
     secrets: inherit


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
